### PR TITLE
fix: baseFontStyle 以 inline style 寫入空段落

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.3.25](https://github.com/iq-service-inc/react-summernote/compare/v2.3.24...v2.3.25)(未發佈)
+
+### fix
+* baseFontStyle 改以 inline style 寫入空段落（`<p style="..."><br></p>`），預設樣式隨 HTML 內容保存，修正儲存後內容在編輯器外顯示不一致；移除 .note-editable 容器 CSS 套用方式 ([37c8ea9](https://github.com/iq-service-inc/react-summernote/commit/37c8ea9))
+  * 行為變更：空編輯器的 value 為帶樣式空段落；動態更新 baseFontStyle 不再改寫既有內容；未使用 baseFontStyle 者行為不變
+
 ## [2.3.24](https://github.com/iq-service-inc/react-summernote/compare/v2.3.23...v2.3.24)(2026-06-25)
 
 ### fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### fix
 * baseFontStyle 改以 inline style 寫入空段落（`<p style="..."><br></p>`），預設樣式隨 HTML 內容保存，修正儲存後內容在編輯器外顯示不一致；移除 .note-editable 容器 CSS 套用方式 ([37c8ea9](https://github.com/iq-service-inc/react-summernote/commit/37c8ea9))
   * 行為變更：空編輯器的 value 為帶樣式空段落；動態更新 baseFontStyle 不再改寫既有內容；未使用 baseFontStyle 者行為不變
+* baseFontStyle 啟用時，全選刪除清單/帶樣式內容後 Chrome 殘留的空殼（`<div><br></div>`、`<div><font><span><br></span></font></div>`）正規化為帶樣式空段落；清單殼 `<ul><li><br></li></ul>` 仍有可見 bullet 屬上游原生行為，不介入 ([9c14eb1](https://github.com/iq-service-inc/react-summernote/commit/9c14eb1))
 
 ## [2.3.24](https://github.com/iq-service-inc/react-summernote/compare/v2.3.23...v2.3.24)(2026-06-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [2.3.25](https://github.com/iq-service-inc/react-summernote/compare/v2.3.24...v2.3.25)(未發佈)
 
 ### fix
-* baseFontStyle 改以 inline style 寫入空段落（`<p style="..."><br></p>`），預設樣式隨 HTML 內容保存，修正儲存後內容在編輯器外顯示不一致；移除 .note-editable 容器 CSS 套用方式 ([37c8ea9](https://github.com/iq-service-inc/react-summernote/commit/37c8ea9))
+* baseFontStyle 改以 inline style 寫入空段落（`<p style="..."><br></p>`），預設樣式隨 HTML 內容保存，修正儲存後內容在編輯器外顯示不一致；移除 .note-editable 容器 CSS 套用方式 ([92fd389](https://github.com/iq-service-inc/react-summernote/commit/92fd389))
   * 行為變更：空編輯器的 value 為帶樣式空段落；動態更新 baseFontStyle 不再改寫既有內容；未使用 baseFontStyle 者行為不變
-* baseFontStyle 啟用時，全選刪除清單/帶樣式內容後 Chrome 殘留的空殼（`<div><br></div>`、`<div><font><span><br></span></font></div>`）正規化為帶樣式空段落；清單殼 `<ul><li><br></li></ul>` 仍有可見 bullet 屬上游原生行為，不介入 ([9c14eb1](https://github.com/iq-service-inc/react-summernote/commit/9c14eb1))
-* baseFontStyle 啟用時，Style 下拉套用 Header/Code 等區塊樣式不生效（inline 字體屬性壓掉標籤原生樣式）；改為套非 P 標籤時剝除受管理屬性、切回 Normal 時補回 baseFontStyle（不蓋既有內容自己的段落樣式） ([40c1c99](https://github.com/iq-service-inc/react-summernote/commit/40c1c99))
+* baseFontStyle 啟用時，全選刪除清單/帶樣式內容後 Chrome 殘留的空殼（`<div><br></div>`、`<div><font><span><br></span></font></div>`）正規化為帶樣式空段落；清單殼 `<ul><li><br></li></ul>` 仍有可見 bullet 屬上游原生行為，不介入 ([8be6753](https://github.com/iq-service-inc/react-summernote/commit/8be6753))
+* baseFontStyle 啟用時，Style 下拉套用 Header/Code 等區塊樣式不生效（inline 字體屬性壓掉標籤原生樣式）；改為套非 P 標籤時剝除受管理屬性、切回 Normal 時補回 baseFontStyle（不蓋既有內容自己的段落樣式） ([e2bb1bf](https://github.com/iq-service-inc/react-summernote/commit/e2bb1bf))
 
 ## [2.3.24](https://github.com/iq-service-inc/react-summernote/compare/v2.3.23...v2.3.24)(2026-06-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * baseFontStyle 改以 inline style 寫入空段落（`<p style="..."><br></p>`），預設樣式隨 HTML 內容保存，修正儲存後內容在編輯器外顯示不一致；移除 .note-editable 容器 CSS 套用方式 ([37c8ea9](https://github.com/iq-service-inc/react-summernote/commit/37c8ea9))
   * 行為變更：空編輯器的 value 為帶樣式空段落；動態更新 baseFontStyle 不再改寫既有內容；未使用 baseFontStyle 者行為不變
 * baseFontStyle 啟用時，全選刪除清單/帶樣式內容後 Chrome 殘留的空殼（`<div><br></div>`、`<div><font><span><br></span></font></div>`）正規化為帶樣式空段落；清單殼 `<ul><li><br></li></ul>` 仍有可見 bullet 屬上游原生行為，不介入 ([9c14eb1](https://github.com/iq-service-inc/react-summernote/commit/9c14eb1))
+* baseFontStyle 啟用時，Style 下拉套用 Header/Code 等區塊樣式不生效（inline 字體屬性壓掉標籤原生樣式）；改為套非 P 標籤時剝除受管理屬性、切回 Normal 時補回 baseFontStyle（不蓋既有內容自己的段落樣式） ([40c1c99](https://github.com/iq-service-inc/react-summernote/commit/40c1c99))
 
 ## [2.3.24](https://github.com/iq-service-inc/react-summernote/compare/v2.3.23...v2.3.24)(2026-06-25)
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ render(
 * `font-size`
 * `color`
 
+預設樣式會以 **inline style** 寫在編輯器的初始空段落上（`<p style="..."><br></p>`），
+使用者輸入的文字與 Enter 產生的新段落都會繼承這些樣式，因此 **`onChange` 取得並儲存的
+HTML 會忠實包含預設樣式**，在編輯器以外的網頁顯示時樣式一致。
+
+注意事項：
+
+* 編輯器為空時，內容值是 `<p style="..."><br></p>`（帶樣式的空段落），
+  不是 `<p><br></p>`；若您的程式以字串比對判斷「空內容」需留意
+  （`isEmpty()` API 不受影響，照常回傳 `true`）
+* 動態更新 `baseFontStyle` 只影響「目前為空的編輯器」與之後清空的狀態，
+  **不會改寫既有內容**（既有內容的樣式以其自身 inline style 為準）
+
 ```jsx
 import React, { Component } from 'react'
 import SummerNote from './SummerNote'

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -7,6 +7,9 @@ import rtf2html from "../lib/trf2html";
 // console.log(SummerNote)
 SummerNote.ImportCode();
 
+// 供 demo 手動驗證/除錯:於瀏覽器 console 直接使用 $('#editor1 > div').summernote(...)
+window.$ = window.jQuery = $;
+
 const htmldata =
 '<p style="vertical-align: top; margin: 0px 0px 1.5em; font-size: 14pt; line-height: 2em; color: rgb(51, 51, 51); font-family: 微軟正黑體, sans-serif; background-color: rgb(247, 247, 247);"><a href="https://ai.facebook.com/blog/open-sourcing-pyrobot-to-accelerate-ai-robotics-research" style="vertical-align: top; color: rgb(0, 0, 0); text-decoration-line: none; border-bottom: 1px dotted rgb(187, 187, 187); padding-bottom: 5px;">臉書與卡內基美隆大學合作，共同開發了機器人控制框架PyRobot</a>，希望讓研究人員能夠在幾小時內，在不需要具備硬體或是裝置驅動程式等相關細節知識，就能啟動並且使機器人開始運作。臉書提到，他們希望提供一個像深度學習開發框架PyTorch這樣的機器人框架，提供一定程度的抽象，以簡化系統建置工作，也讓共享函式庫和工具更為簡單。</p><p style="vertical-align: top; margin: 0px 0px 1.5em; font-size: 14pt; line-height: 2em; color: rgb(51, 51, 51); font-family: 微軟正黑體, sans-serif; background-color: rgb(247, 247, 247);">機器人研究領域有一個笑話，把機器人當作博士研究碖文，論文中的每一個機器人，都會為論文發表時間往後增加一年，臉書提到，要讓機器人揮動手臂，就可能要花上數天甚至一周的時間，來調整機器人軟體，而PyRobot的出現，就是要來解決這樣的研究困境。</p><p style="vertical-align: top; margin: 0px 0px 1.5em; font-size: 14pt; line-height: 2em; color: rgb(51, 51, 51); font-family: 微軟正黑體, sans-serif; background-color: rgb(247, 247, 247);">PyRobot是機器人作業系統ROS上的輕量級高階介面，提供了一組無關硬體的中介API，供開發人員控制各種的機器人，PyRobot抽象了低階控制器與程序之間溝通的細節，因此對於人工智慧研究人員來說，可以不再需要理解機器人的低階操作，能夠專注地建置高階人工智慧機器人應用程式。</p><p class="rtecenter" style="vertical-align: top; margin: 0px 0px 1.5em; text-align: center; font-size: 14pt; line-height: 2em; color: rgb(51, 51, 51); font-family: 微軟正黑體, sans-serif; background-color: rgb(247, 247, 247);"><img alt="" src="https://scontent-tpe1-1.xx.fbcdn.net/v/t39.2365-6/65208991_366432120743262_8971157212042887168_n.gif?_nc_cat=108&amp;_nc_eui2=AeGyV1lVHG2s1TboCa6qoybvi_exikgXF83atf7IgQtcg2ht2rzMSP5Z6vmBlM8ZJcnnfaZ_f_391EouH25dKf_Cm_hcjqrbTPgif4LGSlHNdg&amp;_nc_oc=AQktp8ytYjE29QHmTShUNGjHn7tNgP5lfP-V6p7ApWDkpidjto4pd_Ld9zTFk3vwjsc&amp;_nc_ht=scontent-tpe1-1.xx&amp;oh=649852a5e43ef82748a309c259957b33&amp;oe=5DBB8202" style="vertical-align: middle; max-width: 100%; height: auto; border: 0px; width: 600px;"></p><p style="vertical-align: top; margin: 0px 0px 1.5em; font-size: 14pt; line-height: 2em; color: rgb(51, 51, 51); font-family: 微軟正黑體, sans-serif; background-color: rgb(247, 247, 247);">研究人員可以使用PyRobot中，適用於各種機器人的通用功能，控制機器人關節的位置、速度或是力矩，還能使用複雜的功能，包括笛卡爾路徑規畫或是視覺SLAM等。PyRobot目前雖然僅支援LoCoBot和Sawyer機器人，但還會繼續增加支援各種不同的機器人。PyRobot雖然提供抽象的高階控制，但研究人員依然可以使用不同層級的元件，像是能夠繞過規畫器，直接設定關節速度和力矩等。</p><p style="vertical-align: top; margin: 0px 0px 1.5em; font-size: 14pt; line-height: 2em; color: rgb(51, 51, 51); font-family: 微軟正黑體, sans-serif; background-color: rgb(247, 247, 247);">臉書已經將PyRobot用在各種的機器人應用上，像是點到點的導航，或是推與抓的任務，也用在遠端操作以收集訓練機器人的資料。PyRobot中包含了一些現成的演算法實作，並提供可將自行開發的演算法，簡單地部署到機器人上的方法，臉書也提到，研究人員可以使用PyTorch訓練深度學習模型，並使用PyRobot在機器人上執行演算法。</p><p style="vertical-align: top; margin: 0px 0px 1.5em; font-size: 14pt; line-height: 2em; color: rgb(51, 51, 51); font-family: 微軟正黑體, sans-serif; background-color: rgb(247, 247, 247);">PyRobot可以讓研究社群更容易地使用機器人資料集、演算法實作以及模型，同時也能幫助他們訂定基準，得以互相比較成果，或是基於其他人的成果往前發展，臉書表示，像是在使用LoCoBot這類低成本的機器人平臺，PyRobot有助於降低進入門檻，並使研究成果能夠與其他人分享。臉書也順勢在PyRobot釋出的同時，公開了一項徵求提案活動，任何研究團隊都可以提交PyRobot搭配LoCoBot的研究提案，獲勝者可以贏得一份研究用LoCoBot工具包。</p> <div class="vsc-controller vsc-nosource"></div>  <video width="640" height="360" controls="" autoplay loop muted preload="none"><source src="https://cdn.openai.com/tmp/s/paper-planes.mp4" type="video/mp4">Your browser does not support the video tag.</video>';
 
@@ -119,6 +122,7 @@ class App extends Component {
 						lang: "zh-TW",
 						height: 350,
 						dialogsInBody: true,
+						placeholder: '請輸入內容...',
 						toolbar: [
 							["style", ["style", "customStyle", "copyFormatting"]],
 							["font", ["bold", "italic", "underline", "strikethrough", "superscript", "subscript", "clear", "customCleaner"]],
@@ -152,7 +156,15 @@ class App extends Component {
 					onInit={e => console.log(`Using jquery version ${$().jquery}`)}
 					ref={this.editor1}
 				/>
-				<SummerNote2 id='editor2' onImageUpload={this.onImageUpload2} ref={this.editor2} options={{
+				<h3>editor2:固定 baseFontStyle(標楷體 20px 藍字),初始為空</h3>
+				<SummerNote2 id='editor2' onImageUpload={this.onImageUpload2} ref={this.editor2}
+					baseFontStyle={{
+						'font-family': '標楷體, DFKai-SB, BiauKaiTC',
+						'font-size': '20px',
+						'color': '#0066cc'
+					}}
+					options={{
+					placeholder: '請輸入內容...',
 					toolbar: [
 						["style", ["style", "customStyle", "copyFormatting"]],
 						["font", ["bold", "underline", "clear", "customCleaner"]],
@@ -170,7 +182,20 @@ class App extends Component {
 					],
 					tableClassName: 'jtable table-bordered'
 				}}/>
-				
+
+				<h3>editor3:無 baseFontStyle 對照組(行為應與 v2.3.24 完全相同)</h3>
+				<SummerNote id='editor3' options={{
+					height: 150,
+					placeholder: '請輸入內容...',
+					toolbar: [
+						["font", ["bold", "underline", "clear"]],
+						["fontname", ["customFont"]],
+						["fontsize", ["fontsizeInput"]],
+						['color', ['forecolor']],
+						["view", ["codeview"]],
+					]
+				}}/>
+
 			</div>
 		);
 	}

--- a/src/components/SummerNote.jsx
+++ b/src/components/SummerNote.jsx
@@ -234,6 +234,10 @@ class InnerReactSummernote extends React.Component {
 				notePlaceholder.show();
 			}
 			noteEditable.html(content);
+			// replace 不觸發 summernote change,清空時需在此補回帶樣式空段落
+			if (contentLength === 0 && this.hasActiveBaseFontStyle()) {
+				this.applyBaseFontStyleToEmptyPara(this.props.baseFontStyle);
+			}
 		}
 	}
 
@@ -280,18 +284,60 @@ class InnerReactSummernote extends React.Component {
 		return range
 	}
     
-    // 更新預設字體樣式，於初始化和 baseFontStyle props 變動時呼叫
-    updateBaseFontStyle(baseFontStyle) {
-        // 設定預設字體樣式
-        this.noteEditable.css({
+    // baseFontStyle 是否有有效設定(未提供或三屬性皆空時,相關邏輯一律不執行)
+    isActiveBaseFontStyle(baseFontStyle) {
+        return !!baseFontStyle && !!(baseFontStyle['font-family'] || baseFontStyle['font-size'] || baseFontStyle['color']);
+    }
+
+    hasActiveBaseFontStyle() {
+        return this.isActiveBaseFontStyle(this.props.baseFontStyle);
+    }
+
+    // 組出受管理的三個樣式屬性(值為 '' 時 jQuery.css 會移除該屬性)
+    buildBaseFontStyleCss(baseFontStyle) {
+        return {
             'font-size': baseFontStyle['font-size'] || '',
             'font-family': baseFontStyle['font-family'] || '',
             'color': baseFontStyle['color'] || ''
-        });
+        };
+    }
 
+    // 編輯器視覺為空時,維護帶 inline style 的空段落,使預設樣式隨 HTML 內容保存
+    // 回傳 $para(有套用)或 null(編輯器有內容,不碰)
+    applyBaseFontStyleToEmptyPara(baseFontStyle) {
+        if (!this.noteEditable || !this.noteEditable.length) return null;
+        const dom = $.summernote.dom;
+        const editable = this.noteEditable[0];
+        const css = this.buildBaseFontStyleCss(baseFontStyle);
+
+        // 單一空 <p>(<p><br></p> 或已帶樣式者)→ 就地覆寫三個屬性
+        if (editable.childNodes.length === 1 &&
+            dom.isPara(editable.firstChild) && dom.isEmpty(editable.firstChild)) {
+            const $para = $(editable.firstChild).css(css);
+            // 三屬性皆清除時移除空的 style 屬性,維持與上游 <p><br></p> 一致
+            if (!$para.attr('style')) $para.removeAttr('style');
+            return $para;
+        }
+        // 完全空(如 Ctrl+A 刪除後)→ 重建帶樣式空段落
+        if (dom.isEmpty(editable) && this.isActiveBaseFontStyle(baseFontStyle)) {
+            const $para = $(dom.emptyPara).css(css);
+            this.noteEditable.empty().append($para);
+            // 焦點在編輯器內才回復游標,避免 API 呼叫造成的變更搶走焦點
+            if (editable === document.activeElement || $.contains(editable, document.activeElement)) {
+                const rng = $.summernote.range.create($para[0], 0, $para[0], 0);
+                rng.select();
+                this.editor.summernote('editor.setLastRange', rng);
+            }
+            return $para;
+        }
+        return null;
+    }
+
+    // 更新 toolbar 顯示:字體/字號從帶樣式的空段落讀取(容器已無樣式),顏色按鈕更新預設值
+    syncBaseFontStyleToolbar(baseFontStyle, $para) {
         // 更新 toolbar 字體大小和字體名稱的顯示樣式
-        if (baseFontStyle['font-size']) this.editor.summernote('fontsizeInput.updateFontsizeInput', this.noteEditable);
-        if (baseFontStyle['font-family']) this.editor.summernote('customFont.updateCurrentStyle', false, this.noteEditable);
+        if ($para && baseFontStyle['font-size']) this.editor.summernote('fontsizeInput.updateFontsizeInput', $para);
+        if ($para && baseFontStyle['font-family']) this.editor.summernote('customFont.updateCurrentStyle', false, $para);
 
         // 更新 toolbar 字體顏色的顯示樣式
         if (baseFontStyle['color']) {
@@ -311,6 +357,49 @@ class InnerReactSummernote extends React.Component {
             let $input = $foreButton.find('input[type=color]');
             $input.attr('value', baseFontStyle.color);
         }
+    }
+
+    // 每實例 hook,僅 baseFontStyle 啟用時安裝:
+    // (a) 修正 Editor.isEmpty——上游以 dom.emptyPara === $editable.html() 字串判空,
+    //     帶 style 屬性的空段落會被誤判非空(placeholder 不顯示、isEmpty API 錯誤)
+    // (b) 攔截 context.reset——reset 會重建 modules(isEmpty 覆寫丟失)且結束時
+    //     editable 為無樣式空段落又不觸發 change,需事後重掛與補樣式
+    installBaseFontStyleHooks(baseFontStyle) {
+        if (!this.isActiveBaseFontStyle(baseFontStyle)) return;
+        const context = this.editor.data('summernote');
+        if (!context || !context.modules || !context.modules.editor) return;
+        const self = this;
+        const dom = $.summernote.dom;
+
+        const editorModule = context.modules.editor;
+        if (!editorModule.isEmpty._baseFontStylePatched) {
+            const origIsEmpty = editorModule.isEmpty.bind(editorModule);
+            const patchedIsEmpty = function () {
+                if (origIsEmpty()) return true;
+                const editable = editorModule.$editable[0];
+                return editable.childNodes.length === 1 &&
+                    dom.isPara(editable.firstChild) && dom.isEmpty(editable.firstChild);
+            };
+            patchedIsEmpty._baseFontStylePatched = true;
+            editorModule.isEmpty = patchedIsEmpty;
+        }
+
+        // invoke('reset') 會先查 context 實例屬性,包在實例上即可攔截所有 reset 呼叫
+        if (!context._baseFontStyleResetWrapped) {
+            const origReset = context.reset.bind(context);
+            context.reset = function () {
+                origReset();
+                self.updateBaseFontStyle(self.props.baseFontStyle || {});
+            };
+            context._baseFontStyleResetWrapped = true;
+        }
+    }
+
+    // 更新預設字體樣式,於初始化、baseFontStyle props 變動與內容變空時呼叫
+    updateBaseFontStyle(baseFontStyle) {
+        this.installBaseFontStyleHooks(baseFontStyle);
+        const $para = this.applyBaseFontStyleToEmptyPara(baseFontStyle);
+        this.syncBaseFontStyleToolbar(baseFontStyle, $para);
     }
 
 	handleChange(txt) {
@@ -341,6 +430,14 @@ class InnerReactSummernote extends React.Component {
 		if (typeof onImagePasteFromWord === "function" && this.isPasteFromWord) {
 			this.isPasteFromWord = false
 			onImagePasteFromWord($pastedImgs);
+		}
+
+		// 內容變空時(打字刪光、undo/redo、empty()、codeview 關閉等)重套 baseFontStyle
+		// codeview 開啟期間 editable 尚未同步,不可在此維護也不可重算 txt
+		if (this.hasActiveBaseFontStyle() && !this.editor.summernote('codeview.isActivated')) {
+			this.installBaseFontStyleHooks(this.props.baseFontStyle)
+			const $styledPara = this.applyBaseFontStyleToEmptyPara(this.props.baseFontStyle)
+			if ($styledPara) txt = this.noteEditable.html()
 		}
 
 		if (typeof onChange === "function") onChange(txt);
@@ -460,6 +557,7 @@ InnerReactSummernote.propTypes = {
 	className: PropTypes.string,
 	options: PropTypes.object,
 	disabled: PropTypes.bool,
+	baseFontStyle: PropTypes.object,
 	onInit: PropTypes.func,
 	onEnter: PropTypes.func,
 	onFocus: PropTypes.func,

--- a/src/components/SummerNote.jsx
+++ b/src/components/SummerNote.jsx
@@ -310,16 +310,24 @@ class InnerReactSummernote extends React.Component {
         const editable = this.noteEditable[0];
         const css = this.buildBaseFontStyleCss(baseFontStyle);
 
-        // 單一空 <p>(<p><br></p> 或已帶樣式者)→ 就地覆寫三個屬性
-        if (editable.childNodes.length === 1 &&
-            dom.isPara(editable.firstChild) && dom.isEmpty(editable.firstChild)) {
-            const $para = $(editable.firstChild).css(css);
+        const child = editable.childNodes.length === 1 ? editable.firstChild : null;
+
+        // 單一空段落(<p><br></p> 或已帶樣式者)→ 就地覆寫三個屬性
+        // DIV 除外:交給下方重建,正規化為 <p>(Chrome 刪除內容常以 DIV 當段落)
+        if (child && dom.isPara(child) && child.nodeName !== 'DIV' && dom.isEmpty(child)) {
+            const $para = $(child).css(css);
             // 三屬性皆清除時移除空的 style 屬性,維持與上游 <p><br></p> 一致
             if (!$para.attr('style')) $para.removeAttr('style');
             return $para;
         }
-        // 完全空(如 Ctrl+A 刪除後)→ 重建帶樣式空段落
-        if (dom.isEmpty(editable) && this.isActiveBaseFontStyle(baseFontStyle)) {
+        // 需整個重建帶樣式空段落的兩種「視覺為空」:
+        // (a) 完全空(如 Ctrl+A 刪除後)
+        // (b) 單一深層為空的 <p>/<div> 殘殼——Chrome 解散清單、刪除帶樣式內容時
+        //     會留下 <div><br></div> 或 <div><font><span><br></span></font></div>
+        //     (清單殼 <ul><li><br></li></ul> 仍有可見 bullet,非視覺為空,不在此列)
+        const isDeepEmptyShell = child && /^(P|DIV)$/.test(child.nodeName) &&
+            dom.deepestChildIsEmpty(child);
+        if ((dom.isEmpty(editable) || isDeepEmptyShell) && this.isActiveBaseFontStyle(baseFontStyle)) {
             const $para = $(dom.emptyPara).css(css);
             this.noteEditable.empty().append($para);
             // 焦點在編輯器內才回復游標,避免 API 呼叫造成的變更搶走焦點

--- a/src/components/SummerNote.jsx
+++ b/src/components/SummerNote.jsx
@@ -312,9 +312,10 @@ class InnerReactSummernote extends React.Component {
 
         const child = editable.childNodes.length === 1 ? editable.firstChild : null;
 
-        // 單一空段落(<p><br></p> 或已帶樣式者)→ 就地覆寫三個屬性
-        // DIV 除外:交給下方重建,正規化為 <p>(Chrome 刪除內容常以 DIV 當段落)
-        if (child && dom.isPara(child) && child.nodeName !== 'DIV' && dom.isEmpty(child)) {
+        // 單一空 <p>(<p><br></p> 或已帶樣式者)→ 就地覆寫三個屬性
+        // 僅限 <p>:H1-H6/PRE 等是使用者套用的區塊樣式,重新蓋章會壓掉標籤原生樣式;
+        // DIV 交給下方重建,正規化為 <p>(Chrome 刪除內容常以 DIV 當段落)
+        if (child && child.nodeName === 'P' && dom.isEmpty(child)) {
             const $para = $(child).css(css);
             // 三屬性皆清除時移除空的 style 屬性,維持與上游 <p><br></p> 一致
             if (!$para.attr('style')) $para.removeAttr('style');
@@ -372,6 +373,9 @@ class InnerReactSummernote extends React.Component {
     //     帶 style 屬性的空段落會被誤判非空(placeholder 不顯示、isEmpty API 錯誤)
     // (b) 攔截 context.reset——reset 會重建 modules(isEmpty 覆寫丟失)且結束時
     //     editable 為無樣式空段落又不觸發 change,需事後重掛與補樣式
+    // (c) 攔截 Editor.onFormatBlock——execCommand('FormatBlock') 會把 style 屬性
+    //     原封搬到新標籤,inline 字體屬性壓掉 H1-H6/PRE/BLOCKQUOTE 的原生樣式;
+    //     套非 P 標籤時剝除三個受管理屬性,切回 Normal(P)時補回 baseFontStyle
     installBaseFontStyleHooks(baseFontStyle) {
         if (!this.isActiveBaseFontStyle(baseFontStyle)) return;
         const context = this.editor.data('summernote');
@@ -390,6 +394,34 @@ class InnerReactSummernote extends React.Component {
             };
             patchedIsEmpty._baseFontStylePatched = true;
             editorModule.isEmpty = patchedIsEmpty;
+        }
+
+        if (!editorModule.onFormatBlock._baseFontStylePatched) {
+            const origOnFormatBlock = editorModule.onFormatBlock.bind(editorModule);
+            const patchedOnFormatBlock = function (tagName, $target) {
+                origOnFormatBlock(tagName, $target);
+                const style = self.props.baseFontStyle;
+                if (!self.isActiveBaseFontStyle(style)) return;
+                const upper = String(tagName).toUpperCase();
+                const rng = editorModule.createRange();
+                if (!rng) return;
+                const blocks = rng.nodes(function (n) { return n && n.nodeName === upper; }, { includeAncestor: true });
+                $(blocks).each(function () {
+                    const $block = $(this);
+                    if (upper === 'P') {
+                        // Normal 的視覺 = 預設樣式;未自帶任何受管理屬性才補,
+                        // 避免蓋掉既有內容自己的段落樣式
+                        if (!this.style.fontSize && !this.style.fontFamily && !this.style.color) {
+                            $block.css(self.buildBaseFontStyleCss(style));
+                        }
+                    } else {
+                        $block.css({ 'font-size': '', 'font-family': '', 'color': '' });
+                        if (!$block.attr('style')) $block.removeAttr('style');
+                    }
+                });
+            };
+            patchedOnFormatBlock._baseFontStylePatched = true;
+            editorModule.onFormatBlock = patchedOnFormatBlock;
         }
 
         // invoke('reset') 會先查 context 實例屬性,包在實例上即可攔截所有 reset 呼叫


### PR DESCRIPTION
取代 #7 的程式碼部分——依 review 共識,**排除 `dev-docs/` 與 `CLAUDE.md`(維護者文件不進 master)**,保留全部功能修改與使用者文件。內容與 #7 review 通過的版本完全相同(僅 CHANGELOG 的 commit 連結改指向本分支)。

## 內容

### fix
- **baseFontStyle 改以 inline style 寫入空段落**(92fd389):預設樣式隨 HTML 內容保存,修正儲存後內容在編輯器外顯示不一致;移除 `.note-editable` 容器 CSS 套用方式
  - 行為變更:空編輯器的 value 為帶樣式空段落 `<p style="..."><br></p>`;動態更新 baseFontStyle 不改寫既有內容;未使用 baseFontStyle 者行為不變
- **全選刪除後殘殼正規化**(8be6753):Chrome 殘留的 `<div><br></div>`、`<div><font><span><br></span></font></div>` 收斂為帶樣式空段落;清單殼 `<ul><li><br></li></ul>` 屬上游原生行為,不介入
- **Style 下拉套用區塊樣式不生效修正**(e2bb1bf):套 Header/Code 等非 P 標籤時剝除受管理字體屬性,讓標籤原生樣式生效;切回 Normal 補回 baseFontStyle(不蓋既有內容自己的段落樣式)

### docs
- README 補充 baseFontStyle 行為說明與注意事項、CHANGELOG 2.3.25(未發佈)條目
- demo App.jsx 加入 baseFontStyle 動態調整示範

## 與 #7 的差異

僅移除 `dev-docs/`(5 份維護文件)、`CLAUDE.md` 與對應的 `.npmignore` 兩行;程式碼零差異(可用 `git diff fable fable-code` 驗證,僅顯示上述檔案刪除)。

驗證方式與詳細討論見 #7 的 review 記錄。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
