### PR TITLE
fix: 全選刪除後殘留舊 font family,再輸入時舊字體復活且壓掉 baseFontStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.3.26](https://github.com/iq-service-inc/react-summernote/compare/v2.3.25...v2.3.26)(未發佈)
+
+### fix
+* baseFontStyle 啟用時，圈選文字套用新字體後全選刪除，Chrome typing style 記住刪除前樣式，下次輸入時舊字體復活（`<font face="...">`）並壓掉空段落預設樣式、toolbar 字體顯示殘留；改為空段落就地正規化時一併重設 selection 清除 typing style（原僅重建分支有回復游標） ([bbaa36c](https://github.com/iq-service-inc/react-summernote/commit/bbaa36c))
+
 ## [2.3.25](https://github.com/iq-service-inc/react-summernote/compare/v2.3.24...v2.3.25)(2026-07-03)
 
 ### fix

--- a/src/components/SummerNote.jsx
+++ b/src/components/SummerNote.jsx
@@ -302,6 +302,19 @@ class InnerReactSummernote extends React.Component {
         };
     }
 
+    // 焦點在編輯器內才回復游標,避免 API 呼叫造成的變更搶走焦點
+    // 重設 selection 同時清除 WebKit 的 typing style——Chrome 全選刪除後會記住
+    // 刪除前的 inline 樣式(如選字套用的 font-family),下次輸入時原樣復活
+    // 並壓掉空段落上的預設樣式,必須在內容變空當下重設 selection 使其失效
+    restoreCaretToPara($para) {
+        const editable = this.noteEditable[0];
+        if (editable === document.activeElement || $.contains(editable, document.activeElement)) {
+            const rng = $.summernote.range.create($para[0], 0, $para[0], 0);
+            rng.select();
+            this.editor.summernote('editor.setLastRange', rng);
+        }
+    }
+
     // 編輯器視覺為空時,維護帶 inline style 的空段落,使預設樣式隨 HTML 內容保存
     // 回傳 $para(有套用)或 null(編輯器有內容,不碰)
     applyBaseFontStyleToEmptyPara(baseFontStyle) {
@@ -319,6 +332,7 @@ class InnerReactSummernote extends React.Component {
             const $para = $(child).css(css);
             // 三屬性皆清除時移除空的 style 屬性,維持與上游 <p><br></p> 一致
             if (!$para.attr('style')) $para.removeAttr('style');
+            this.restoreCaretToPara($para);
             return $para;
         }
         // 需整個重建帶樣式空段落的兩種「視覺為空」:
@@ -331,12 +345,7 @@ class InnerReactSummernote extends React.Component {
         if ((dom.isEmpty(editable) || isDeepEmptyShell) && this.isActiveBaseFontStyle(baseFontStyle)) {
             const $para = $(dom.emptyPara).css(css);
             this.noteEditable.empty().append($para);
-            // 焦點在編輯器內才回復游標,避免 API 呼叫造成的變更搶走焦點
-            if (editable === document.activeElement || $.contains(editable, document.activeElement)) {
-                const rng = $.summernote.range.create($para[0], 0, $para[0], 0);
-                rng.select();
-                this.editor.summernote('editor.setLastRange', rng);
-            }
+            this.restoreCaretToPara($para);
             return $para;
         }
         return null;

--- a/src/components/SummerNote.jsx
+++ b/src/components/SummerNote.jsx
@@ -324,31 +324,33 @@ class InnerReactSummernote extends React.Component {
         const css = this.buildBaseFontStyleCss(baseFontStyle);
 
         const child = editable.childNodes.length === 1 ? editable.firstChild : null;
+        let $para = null;
 
         // 單一空 <p>(<p><br></p> 或已帶樣式者)→ 就地覆寫三個屬性
         // 僅限 <p>:H1-H6/PRE 等是使用者套用的區塊樣式,重新蓋章會壓掉標籤原生樣式;
         // DIV 交給下方重建,正規化為 <p>(Chrome 刪除內容常以 DIV 當段落)
         if (child && child.nodeName === 'P' && dom.isEmpty(child)) {
-            const $para = $(child).css(css);
+            $para = $(child).css(css);
             // 三屬性皆清除時移除空的 style 屬性,維持與上游 <p><br></p> 一致
             if (!$para.attr('style')) $para.removeAttr('style');
-            this.restoreCaretToPara($para);
-            return $para;
+        } else {
+            // 需整個重建帶樣式空段落的兩種「視覺為空」:
+            // (a) 完全空(如 Ctrl+A 刪除後)
+            // (b) 單一深層為空的 <p>/<div> 殘殼——Chrome 解散清單、刪除帶樣式內容時
+            //     會留下 <div><br></div> 或 <div><font><span><br></span></font></div>
+            //     (清單殼 <ul><li><br></li></ul> 仍有可見 bullet,非視覺為空,不在此列)
+            const isDeepEmptyShell = child && /^(P|DIV)$/.test(child.nodeName) &&
+                dom.deepestChildIsEmpty(child);
+            if ((dom.isEmpty(editable) || isDeepEmptyShell) && this.isActiveBaseFontStyle(baseFontStyle)) {
+                $para = $(dom.emptyPara).css(css);
+                this.noteEditable.empty().append($para);
+            }
         }
-        // 需整個重建帶樣式空段落的兩種「視覺為空」:
-        // (a) 完全空(如 Ctrl+A 刪除後)
-        // (b) 單一深層為空的 <p>/<div> 殘殼——Chrome 解散清單、刪除帶樣式內容時
-        //     會留下 <div><br></div> 或 <div><font><span><br></span></font></div>
-        //     (清單殼 <ul><li><br></li></ul> 仍有可見 bullet,非視覺為空,不在此列)
-        const isDeepEmptyShell = child && /^(P|DIV)$/.test(child.nodeName) &&
-            dom.deepestChildIsEmpty(child);
-        if ((dom.isEmpty(editable) || isDeepEmptyShell) && this.isActiveBaseFontStyle(baseFontStyle)) {
-            const $para = $(dom.emptyPara).css(css);
-            this.noteEditable.empty().append($para);
-            this.restoreCaretToPara($para);
-            return $para;
-        }
-        return null;
+
+        // 收斂點:任一分支有維護空段落,一律在此回復游標(同時清除 typing style)
+        // 不交由各分支自行處理,避免新增分支時遺漏後置動作
+        if ($para) this.restoreCaretToPara($para);
+        return $para;
     }
 
     // 更新 toolbar 顯示:字體/字號從帶樣式的空段落讀取(容器已無樣式),顏色按鈕更新預設值


### PR DESCRIPTION
## 問題(重現步驟)

在有 baseFontStyle 的**空編輯器**中:

1. 輸入一些文字
2. 圈選文字,套用一個新的 font family(如 Arial)
3. Ctrl+A 全選,按 Backspace 刪除全部內容

此時編輯器內容已清空,但剛才設定的 font family 殘留:

- **再輸入文字時舊字體復活**:輸出變成 `<p style="font-size:20px; color:...."><font face="Arial">X</font></p>` — 不但以 `<font face>` 包住新輸入的字,連空段落上的預設 `font-family` 都被移除
- **toolbar 字體顯示殘留** Arial,使用者誤以為預設樣式沒有生效

## 調查發現

**殘留的不是 DOM。** 實測刪除後的 DOM 快照,#8 的正規化其實有正確運作,內容已收斂為帶 baseFontStyle 的空段落:

```html
<p style="font-size: 20px; font-family: 標楷體, DFKai-SB, BiauKaiTC; color: rgb(0, 102, 204);"><br></p>
```

真正的元兇是 **Chrome(WebKit)內部的 typing style**:對選取範圍執行刪除時,Chrome 會記住刪除前游標處的 inline 樣式(即步驟 2 套用的 font family),與 DOM 無關、無法從 HTML 觀察到。下一次輸入時 Chrome 將這份記憶原樣重放——插入 `<font face="Arial">` 並把段落上衝突的 `font-family` 屬性往下推(移除)。

**為什麼 #8 沒擋住:** typing style 會在 selection 被重新設定時失效。#8 的空段落正規化有兩個分支:

| 分支 | 觸發情境 | 是否重設 selection |
|---|---|---|
| 重建空段落 | 完全空、deep-empty 殘殼(`<div><font><span><br></span></font></div>` 等) | ✅ 有回復游標(附帶清掉 typing style) |
| 就地覆寫單一空 `<p>` | Chrome 保留原本帶樣式的 `<p>` 時(本 bug 情境) | ❌ 只改 css,typing style 存活 |

本情境中 Chrome 刪除後保留了原本的 `<p style="base...">`,走的是「就地覆寫」分支,typing style 因此活到下一次輸入。

**toolbar 殘留是同一根源的副作用**:summernote 的 change 事件流程是 callbacks 先執行、再觸發 plugin 的 `summernote.change` handler(`Context.triggerEvent`)。只要我們在 callback(`handleChange` → 正規化)中把 selection 與 lastRange 重設到正規化後的段落,後續 customFont/buttons 的 `updateCurrentStyle` 讀 `editor.currentStyle` 就會拿到正確的段落樣式,toolbar 顯示自動修正,不需要額外同步。

另外註記:打字/刪除觸發的 change 是 debounce 10ms 的 input handler(上游 Editor.js),所以正規化與 selection 重設發生在刪除後約 10ms——遠早於真實使用者的下一次鍵入,時序上安全。

## 解決方式

把「重建空段落」分支既有的游標回復邏輯抽成 `restoreCaretToPara($para)`,**兩個正規化分支都執行**:

- 保留原本的焦點防護(焦點在編輯器內才重設 selection,避免 API 呼叫造成的變更搶走焦點)
- 於內容變空當下重設 selection + `editor.setLastRange`,使 Chrome typing style 失效

僅重構 + 就地覆寫分支補上一行呼叫,無新增狀態;未使用 baseFontStyle 者完全不受影響(整段邏輯仍由 `hasActiveBaseFontStyle()` 把關)。

## 驗證記錄(demo editor2:標楷體 20px 藍字 baseFontStyle)

主情境(修復前 → 後):

- 刪除後再輸入:`<font face="Arial">X</font>` + P 失去 font-family → `<p style="…標楷體…">X</p>` 正確繼承預設樣式
- 刪除後 toolbar 字體顯示:`Arial` → `標楷體`

迴歸測試全數通過:

- 空編輯器 collapsed 游標選字體 → bogus span(ZWSP)流程不受正規化干擾,後續輸入正確進入所選字體的 span
- 逐字 Backspace 刪光 → 行為與全選刪除一致,重打字套預設樣式
- 全選刪除後對 font-size 的殘留(同機制)一併修復
- editor1(動態 baseFontStyle + 既有內容):全選刪除因含 video 元素未真正清空時,正規化正確不介入
- editor3(無 baseFontStyle 對照組):行為與 v2.3.24 完全相同(`<font face>` 殘留屬上游原生行為,不介入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
